### PR TITLE
Query for previous runs at every iteration of the Waiter

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,9 +1,10 @@
 name: Main
 
-on: push
+on: [push, pull_request]
 
 jobs:
   build:
+    if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     steps:
       # https://github.com/actions/checkout
@@ -18,6 +19,7 @@ jobs:
       - name: Format
         run: npm run fmtcheck
   integration:
+    if: github.event_name == 'push'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/__tests__/wait.test.ts
+++ b/__tests__/wait.test.ts
@@ -1,20 +1,55 @@
 import * as assert from "assert";
+
 import { Waiter } from "../src/wait";
+import { Input } from "../src/input";
+import { Workflow, Run } from "../src/github";
 
 describe("wait", () => {
   describe("Waiter", () => {
     describe("wait", () => {
+      let input: Input;
+      const workflow: Workflow = {
+        id: 123124,
+        name: "Test workflow"
+      };
+
+      beforeEach(() => {
+        input = {
+          branch: "master",
+          continueAfterSeconds: 1,
+          pollIntervalSeconds: 1,
+          githubToken: "fake-token",
+          owner: "org",
+          repo: "repo",
+          runId: 2,
+          workflowName: workflow.name
+        };
+      });
+
       it("will continue after a prescribed number of seconds", async () => {
+        const inProgressRun = {
+          id: 1,
+          status: "in_progress",
+          html_url: ""
+        };
+        const githubClient = {
+          runs: async (
+            owner: string,
+            repo: string,
+            branch: string,
+            workflowId: number
+          ) => Promise.resolve([inProgressRun]),
+          run: async (owner: string, repo: string, runId: number) =>
+            Promise.resolve(inProgressRun),
+          workflows: async (owner: string, repo: string) =>
+            Promise.resolve([workflow])
+        };
+
         const messages: Array<string> = [];
         const waiter = new Waiter(
-          () =>
-            Promise.resolve({
-              id: 1,
-              status: "in_progress",
-              html_url: ""
-            }),
-          1,
-          1,
+          workflow.id,
+          githubClient,
+          input,
           (message: string) => {
             messages.push(message);
           }
@@ -27,22 +62,127 @@ describe("wait", () => {
       });
 
       it("will return when a run is completed", async () => {
+        const completedRun: Run = {
+          id: 1,
+          status: "completed",
+          html_url: ""
+        };
+        const githubClient = {
+          runs: async (
+            owner: string,
+            repo: string,
+            branch: string,
+            workflowId: number
+          ) => Promise.resolve([completedRun]),
+          run: async (owner: string, repo: string, runId: number) =>
+            Promise.resolve(completedRun),
+          workflows: async (owner: string, repo: string) =>
+            Promise.resolve([workflow])
+        };
+
         const messages: Array<string> = [];
         const waiter = new Waiter(
-          () =>
-            Promise.resolve({
-              id: 1,
-              status: "completed",
-              html_url: ""
-            }),
-          1,
-          1,
+          workflow.id,
+          githubClient,
+          input,
           (message: string) => {
             messages.push(message);
           }
         );
         assert.equal(await waiter.wait(), 0);
         assert.deepEqual(messages, ["👍 Run  complete."]);
+      });
+
+      it("will wait for all previous runs", async () => {
+        // Set continueAfterSeconds to `undefined` to simulate waiting
+        // for all runs to complete before proceeding.
+        input.continueAfterSeconds = undefined;
+        const inProgressRuns = [
+          {
+            id: 1,
+            status: "in_progress",
+            html_url: "1"
+          },
+          {
+            id: 2,
+            status: "in_progress",
+            html_url: "2"
+          },
+          {
+            id: 3,
+            status: "in_progress",
+            html_url: "3"
+          }
+        ];
+        // Give the current run an id that makes it the last in the queue.
+        input.runId = inProgressRuns.length + 1;
+        const mockedRunsFunc = jest.fn();
+        mockedRunsFunc
+          .mockReturnValueOnce(Promise.resolve(inProgressRuns.slice(0)))
+          .mockReturnValueOnce(Promise.resolve(inProgressRuns.slice(0, 2)))
+          .mockReturnValue(Promise.resolve(inProgressRuns));
+
+        /**
+         * Simulate waiting for a previous run for 3s and then completing
+         * the previous run.
+         *
+         * Setup the "run" function to return the run information as-is,
+         * which means the previous run will appear as "in-progress" until
+         * we mutate the "status" ourselves.
+         */
+        const mockedRunFunc = jest
+          .fn()
+          .mockImplementationOnce(
+            async (owner: string, repo: string, runId: number) => {
+              const r = inProgressRuns.find(v => v.id === runId);
+              return Promise.resolve(r!);
+            }
+          )
+          .mockImplementationOnce(
+            async (owner: string, repo: string, runId: number) => {
+              const r = inProgressRuns.find(v => v.id === runId);
+              return Promise.resolve(r!);
+            }
+          )
+          .mockImplementationOnce(
+            async (owner: string, repo: string, runId: number) => {
+              const r = inProgressRuns.find(v => v.id === runId);
+              return Promise.resolve(r!);
+            }
+          )
+          .mockImplementation(
+            async (owner: string, repo: string, runId: number) => {
+              const r = inProgressRuns.find(v => v.id === runId);
+              // Modify the run status to completed to simulate a run completing.
+              r!.status = "completed";
+              return Promise.resolve(r!);
+            }
+          );
+
+        const githubClient = {
+          runs: mockedRunsFunc,
+          run: mockedRunFunc,
+          workflows: async (owner: string, repo: string) =>
+            Promise.resolve([workflow])
+        };
+
+        const messages: Array<string> = [];
+        const waiter = new Waiter(
+          workflow.id,
+          githubClient,
+          input,
+          (message: string) => {
+            messages.push(message);
+          }
+        );
+        await waiter.wait();
+        // Verify that the last message printed is that the latest previous run
+        // is complete and not the oldest one.
+        const latestPreviousRun = inProgressRuns[inProgressRuns.length - 1];
+        assert.deepEqual(
+          messages[messages.length - 1],
+          `👍 Run ${latestPreviousRun.html_url} complete.`
+        );
       });
     });
   });

--- a/src/github.ts
+++ b/src/github.ts
@@ -20,7 +20,6 @@ export interface GitHub {
     branch: string,
     workflow_id: number
   ) => Promise<Array<Run>>;
-  run: (owner: string, repo: string, run_id: number) => Promise<Run>;
 }
 
 export class OctokitGitHub implements GitHub {
@@ -72,13 +71,4 @@ export class OctokitGitHub implements GitHub {
         status: "in_progress"
       })
     );
-
-  run = async (owner: string, repo: string, run_id: number) => {
-    const response = await this.octokit.actions.getWorkflowRun({
-      owner,
-      repo,
-      run_id
-    });
-    return response.data;
-  };
 }

--- a/src/wait.ts
+++ b/src/wait.ts
@@ -1,4 +1,5 @@
-import { Run } from "./github";
+import { Run, OctokitGitHub, GitHub } from "./github";
+import { Input, parseInput } from "./input";
 
 export interface Wait {
   wait(secondsSoFar?: number): Promise<number>;
@@ -6,38 +7,55 @@ export interface Wait {
 
 export class Waiter implements Wait {
   private readonly info: (msg: string) => void;
-  private readonly getRun: () => Promise<Run>;
-  private readonly pollIntervalSeconds: number;
-  private readonly continueAfterSeconds: number | undefined;
+  private input: Input;
+  private githubClient: GitHub;
+  private workflowId: any;
+
   constructor(
-    getRun: () => Promise<Run>,
-    pollIntervalSeconds: number,
-    continueAfterSeconds: number | undefined,
+    workflowId: any,
+    githubClient: GitHub,
+    input: Input,
     info: (msg: string) => void
   ) {
-    this.getRun = getRun;
-    this.pollIntervalSeconds = pollIntervalSeconds;
-    this.continueAfterSeconds = continueAfterSeconds;
+    this.workflowId = workflowId;
+    this.input = input;
+    this.githubClient = githubClient;
     this.info = info;
   }
 
   wait = async (secondsSoFar?: number) => {
+    const runs = await this.githubClient.runs(
+      this.input.owner,
+      this.input.repo,
+      this.input.branch,
+      this.workflowId
+    );
+    const previousRun = runs
+      .filter(run => run.id < this.input.runId)
+      .sort((a, b) => b.id - a.id)[0];
+
     if (
-      this.continueAfterSeconds &&
-      (secondsSoFar || 0) >= this.continueAfterSeconds
+      this.input.continueAfterSeconds &&
+      (secondsSoFar || 0) >= this.input.continueAfterSeconds
     ) {
       this.info(`🤙Exceeded wait seconds. Continuing...`);
       return secondsSoFar || 0;
     }
-    const run = await this.getRun();
+
+    const run = await this.githubClient.run(
+      this.input.owner,
+      this.input.repo,
+      previousRun.id
+    );
     if (run.status === "completed") {
       this.info(`👍 Run ${run.html_url} complete.`);
       return secondsSoFar || 0;
     }
+
     this.info(`✋Awaiting run ${run.html_url}...`);
     await new Promise(resolve =>
-      setTimeout(resolve, this.pollIntervalSeconds * 1000)
+      setTimeout(resolve, this.input.pollIntervalSeconds * 1000)
     );
-    return this.wait((secondsSoFar || 0) + this.pollIntervalSeconds);
+    return this.wait((secondsSoFar || 0) + this.input.pollIntervalSeconds);
   };
 }


### PR DESCRIPTION
Fixes #3.

I believe this should fix the issue where the Action was querying for previous runs. I have also updated the sort order to be descending, so that each run awaits its immediate previous run.

Also, updated existing tests and added a new one for validating waiting for multiple previous runs.

Please feel free to use any part of this PR to your liking if you feel you would like to do something different to fix what we discussed in #3.