### PR TITLE
feature: support GitHub Enterprise

### DIFF
--- a/src/github.ts
+++ b/src/github.ts
@@ -7,6 +7,7 @@ export class OctokitGitHub {
   constructor(githubToken: string) {
     Octokit.plugin(require("@octokit/plugin-throttling"));
     this.octokit = new Octokit({
+      baseUrl: process.env["GITHUB_API_URL"] || "https://api.github.com",
       auth: githubToken,
       throttle: {
         onRateLimit: (retryAfter, options) => {


### PR DESCRIPTION
GitHub Actions sets the environment variable GITHUB_API_URL to the API URL of the instance of GitHub.  For example, if running on github.com, then GITHUB_API_URL will be https://api.github.com; if running on ghe.my-company.com, then GITHUB_API_URL will be https://ghe.my-company.com/api/v3.

By setting the baseUrl of Octokit to the GITHUB_API_URL environment variable, any instance of GitHub Actions is supported, github.com or GitHub Enterprise.