### PR TITLE
[codex] remove ncc in favor of esbuild

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,6 @@
       },
       "devDependencies": {
         "@types/node": "^24.12.0",
-        "@vercel/ncc": "^0.38.4",
         "@vitest/coverage-v8": "^4.1.2",
         "esbuild": "^0.27.5",
         "husky": "^9.1.7",
@@ -1132,16 +1131,6 @@
       "license": "MIT",
       "dependencies": {
         "undici-types": "~7.16.0"
-      }
-    },
-    "node_modules/@vercel/ncc": {
-      "version": "0.38.4",
-      "resolved": "https://registry.npmjs.org/@vercel/ncc/-/ncc-0.38.4.tgz",
-      "integrity": "sha512-8LwjnlP39s08C08J5NstzriPvW1SP8Zfpp1BvC2sI35kPeZnHfxVkCwu4/+Wodgnd60UtT1n8K8zw+Mp7J9JmQ==",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "ncc": "dist/ncc/cli.js"
       }
     },
     "node_modules/@vitest/coverage-v8": {

--- a/package.json
+++ b/package.json
@@ -30,10 +30,9 @@
     "@octokit/rest": "^22.0.1"
   },
   "devDependencies": {
-    "esbuild": "^0.27.5",
     "@types/node": "^24.12.0",
-    "@vercel/ncc": "^0.38.4",
     "@vitest/coverage-v8": "^4.1.2",
+    "esbuild": "^0.27.5",
     "husky": "^9.1.7",
     "lint-staged": "^16.4.0",
     "prettier": "^3.8.1",


### PR DESCRIPTION
## Summary
- remove the unused `@vercel/ncc` devDependency
- keep the existing `esbuild`-based `dist/index.js` build path unchanged
- refresh `package-lock.json` to match the reduced toolchain

## Why
`action.yml` runs this action on Node 24 and the repo already builds the runtime bundle with `esbuild`. `ncc` was leftover dependency state and is no longer part of the build path.

## Validation
- `npm run build`
- `npm run typecheck`
- `npm test`