### PR TITLE
chore: add 7-day cooldown to dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,6 +15,8 @@ updates:
       - dependency-name: "@types/node"
         versions:
           - ">=25.0.0"
+    cooldown:
+      default-days: 7
     commit-message:
       prefix: "chore(deps)"
   - package-ecosystem: github-actions
@@ -25,5 +27,7 @@ updates:
       npm:
         patterns:
           - "*"
+    cooldown:
+      default-days: 7
     commit-message:
       prefix: "chore(deps)"


### PR DESCRIPTION
Add `cooldown: default-days: 7` to both npm and github-actions ecosystems to prevent rapid successive dependency update PRs.